### PR TITLE
Escape one ' in explode example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Using Technicolor it's possible to transform the above function into the one bel
 
 ```fish
 function explode
-  echo (tint: red (bold: 'Error:')) (tint: red 'You can't explode')
+  echo (tint: red (bold: 'Error:')) (tint: red 'You can\'t explode')
 end
 ```
 


### PR DESCRIPTION
Alternatively one could use "You can't explode" in favor of 'You can\'t explode'...